### PR TITLE
Normalize files using .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto
+
+*.ts text
+*.js text
+*.md text
+*.json text
+*.yml text
+
+.npmignore text
+
+*.png binary


### PR DESCRIPTION
To prevent any mixing with `CRLF`'s (Windows' default end of line) in the text-files of the project, "normalize" the files (convert them to `LF`, EOL for *nix, but they already are) and keep them normalized using a `.gitattributes`. This should ensure that the text-files always uses `LF`. Windows users can decide if they want to pull with `CRLF` (`core.autocrlf` in their git settings), but committing always uses `LF`.

More info: https://git-scm.com/docs/gitattributes

<sup>I know that I don't commit actual code, I'm sorry.</sup>